### PR TITLE
Microsoft Certification requirement

### DIFF
--- a/Code/Shared Assembly Info/SharedAssemblyInfo.cs
+++ b/Code/Shared Assembly Info/SharedAssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyCompany("PureKrome & Yahoo")]
+[assembly: AssemblyCompany("The PureRanger Partnership")]
 [assembly: AssemblyProduct("YUI Compressor .NET")]
 [assembly: AssemblyCopyright("Copyright © 2008")]
 [assembly: AssemblyTrademark("")]

--- a/Code/Shared Assembly Info/SharedAssemblyInfo.cs
+++ b/Code/Shared Assembly Info/SharedAssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("PureKrome & Yahoo")]
 [assembly: AssemblyProduct("YUI Compressor .NET")]
 [assembly: AssemblyCopyright("Copyright © 2008")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
Microsoft Certification requires all referenced DLLs to have a provided "Company" name. Added one to pass this check.