### PR TITLE
Implement DisallowNakedComma option for #9

### DIFF
--- a/Code/Yahoo.Yui.Compressor.Build.MsBuild/JavaScriptCompressorTask.cs
+++ b/Code/Yahoo.Yui.Compressor.Build.MsBuild/JavaScriptCompressorTask.cs
@@ -21,6 +21,8 @@ namespace Yahoo.Yui.Compressor.Build.MsBuild
 
         public bool IsEvalIgnored { get; set; }
 
+        public bool DisallowNakedComma { get; set; }
+
         public JavaScriptCompressorTask() : this(new JavaScriptCompressor())
         {
         }
@@ -72,6 +74,7 @@ namespace Yahoo.Yui.Compressor.Build.MsBuild
         {
             compressor.DisableOptimizations = DisableOptimizations;
             compressor.IgnoreEval = IsEvalIgnored;
+            compressor.DisallowNakedComma = DisallowNakedComma;
             compressor.ObfuscateJavascript = ObfuscateJavaScript;
             compressor.PreserveAllSemicolons = PreserveAllSemicolons;
             compressor.ThreadCulture = threadCulture;
@@ -85,6 +88,7 @@ namespace Yahoo.Yui.Compressor.Build.MsBuild
             TaskEngine.Log.LogBoolean("Preserve semi colons", PreserveAllSemicolons);
             TaskEngine.Log.LogBoolean("Disable optimizations", DisableOptimizations);
             TaskEngine.Log.LogBoolean("Is Eval Ignored", IsEvalIgnored);
+            TaskEngine.Log.LogBoolean("Disallow Naked Commas", DisallowNakedComma);
             TaskEngine.Log.LogMessage(
                 "Line break position: "
                 + (LineBreakPosition <= -1 ? "None" : LineBreakPosition.ToString(CultureInfo.InvariantCulture)));

--- a/Code/Yahoo.Yui.Compressor.Build.Nant/JavaScriptCompressorTask.cs
+++ b/Code/Yahoo.Yui.Compressor.Build.Nant/JavaScriptCompressorTask.cs
@@ -29,6 +29,9 @@ namespace Yahoo.Yui.Compressor.Build.Nant
         [TaskAttribute("isEvalIgnored")]
         public bool IsEvalIgnored { get; set; }
 
+        [TaskAttribute("disallowNakedComma")]
+        public bool DisallowNakedComma { get; set; }
+
         public JavaScriptCompressorTask() : this(new JavaScriptCompressor())
         {
         }
@@ -79,6 +82,7 @@ namespace Yahoo.Yui.Compressor.Build.Nant
         {
             compressor.DisableOptimizations = DisableOptimizations;
             compressor.IgnoreEval = IsEvalIgnored;
+            compressor.DisallowNakedComma = DisallowNakedComma;
             compressor.ObfuscateJavascript = ObfuscateJavaScript;
             compressor.PreserveAllSemicolons = PreserveAllSemicolons;
             compressor.ThreadCulture = threadCulture;

--- a/Code/Yahoo.Yui.Compressor.Tests/JavaScriptCompressorTest.cs
+++ b/Code/Yahoo.Yui.Compressor.Tests/JavaScriptCompressorTest.cs
@@ -690,6 +690,67 @@ namespace Yahoo.Yui.Compressor.Tests
         }
 
         [Test]
+        [Description("https://github.com/PureKrome/YUICompressor.NET/issues/9")]
+        public void DisallowNakedCommaWarning()
+        {
+            const string arrayDeclarationBadSource = @"var anArray = [1,'2',];";
+            const string arrayDeclarationGoodSource = @"var anArray = [1,'2',3];";
+            const string objectDeclarationBadSource = @"var anObject = {a:1,b:'2',};";
+            const string objectDeclarationGoodSource = @"var anObject = {a:1,b:'2',c:3};";
+
+            target.LoggingType = LoggingType.Debug;
+
+            // Test with the DisallowNakedComma disabled, for backwards compatibility.
+            // Act 
+            target.Compress(arrayDeclarationBadSource);
+            
+            // Assert
+            var reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred with the option disabled.");
+
+            // Act
+            target.Compress(arrayDeclarationGoodSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred that shouldn't have.");
+            
+            // Act
+            target.Compress(objectDeclarationBadSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred with the option disabled.");
+            
+            // Act
+            target.Compress(objectDeclarationGoodSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred that shouldn't have.");
+
+            target.DisallowNakedComma = true;
+
+            // Act
+            target.Compress(arrayDeclarationBadSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.Not.EqualTo(0), "Warning missing with the option enabled.");
+            target.ErrorReporter = null; // reset
+
+            // Act
+            target.Compress(arrayDeclarationGoodSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred that shouldn't have.");
+
+            // Act
+            target.Compress(objectDeclarationBadSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.Not.EqualTo(0), "Warning missing with the option enabled.");
+            target.ErrorReporter = null; // reset
+
+            // Act
+            target.Compress(objectDeclarationGoodSource);
+            reporter = (CustomErrorReporter)target.ErrorReporter;
+            Assert.That(reporter.ErrorMessages.Count, Is.EqualTo(0), "A Warning occurred that shouldn't have.");
+
+            target.DisallowNakedComma = false; // restore default configuration for any following tests.
+        }
+
+        [Test]
         [Description("http://yuicompressor.codeplex.com/workitem/10742")]
         public void Compressing_A_File_With_A_Unicode_BOM_Character_At_Start_Of_File_Should_Succeed()
         {

--- a/Code/Yahoo.Yui.Compressor.Web.Optimization/JavaScriptCompressorConfig.cs
+++ b/Code/Yahoo.Yui.Compressor.Web.Optimization/JavaScriptCompressorConfig.cs
@@ -13,6 +13,7 @@ namespace Yahoo.Yui.Compressor.Web.Optimization
             ObfuscateJavascript = true;
             PreserveAllSemicolons = false;
             IgnoreEval = false;
+            DisallowNakedComma = false;
             ThreadCulture = CultureInfo.InvariantCulture;
         }
 
@@ -22,6 +23,7 @@ namespace Yahoo.Yui.Compressor.Web.Optimization
         public bool ObfuscateJavascript { get; set; }
         public bool PreserveAllSemicolons { get; set; }
         public bool IgnoreEval { get; set; }
+        public bool DisallowNakedComma { get; set; }
         public CultureInfo ThreadCulture { get; set; }
         public LoggingType LoggingType { get; set; }
     }

--- a/Code/Yahoo.Yui.Compressor.Web.Optimization/YuiCompressorTransform.cs
+++ b/Code/Yahoo.Yui.Compressor.Web.Optimization/YuiCompressorTransform.cs
@@ -86,6 +86,7 @@ namespace Yahoo.Yui.Compressor.Web.Optimization
                     Encoding = jsCompressorConfig.Encoding,
                     ErrorReporter = jsCompressorConfig.ErrorReporter,
                     IgnoreEval = jsCompressorConfig.IgnoreEval,
+                    DisallowNakedComma = jsCompressorConfig.DisallowNakedComma,
                     LineBreakPosition = jsCompressorConfig.LineBreakPosition,
                     LoggingType = jsCompressorConfig.LoggingType,
                     ObfuscateJavascript = jsCompressorConfig.ObfuscateJavascript,

--- a/Code/Yahoo.Yui.Compressor/IJavaScriptCompressor.cs
+++ b/Code/Yahoo.Yui.Compressor/IJavaScriptCompressor.cs
@@ -13,6 +13,7 @@ namespace Yahoo.Yui.Compressor
         bool IgnoreEval { get; set; }
         bool ObfuscateJavascript { get; set; }
         bool PreserveAllSemicolons { get; set; }
+        bool DisallowNakedComma { get; set; }
         CultureInfo ThreadCulture { get; set; }
     }
 }

--- a/Code/Yahoo.Yui.Compressor/JavaScriptCompressor.cs
+++ b/Code/Yahoo.Yui.Compressor/JavaScriptCompressor.cs
@@ -45,6 +45,7 @@ namespace Yahoo.Yui.Compressor
         public bool ObfuscateJavascript { get; set; }
         public bool PreserveAllSemicolons { get; set; }
         public bool IgnoreEval { get; set; }
+        public bool DisallowNakedComma { get; set; }
         public CultureInfo ThreadCulture { get; set; }
         public override string ContentType { get { return "text/javascript"; } }
 
@@ -67,6 +68,7 @@ namespace Yahoo.Yui.Compressor
         public JavaScriptCompressor()
         {
             ObfuscateJavascript = true;
+            DisallowNakedComma = false;
             Encoding = Encoding.Default;
             ThreadCulture = CultureInfo.InvariantCulture;
         }
@@ -1070,6 +1072,14 @@ namespace Yahoo.Yui.Compressor
                             parensNesting == 0)
                         {
                             return;
+                        }
+                        if (DisallowNakedComma && token.TokenType == Token.COMMA)
+                        {
+                            JavaScriptToken nextToken = GetToken(0); // peek at next token
+                            if ((nextToken.TokenType == Token.RB) || (nextToken.TokenType == Token.RC))
+                            {
+                                Warn("A naked comma in an array or object declaration will cause an exception in IE7 and earlier.");
+                            }
                         }
                         break;
 


### PR DESCRIPTION
To close #9 -Add option to detect and warn of Javascript object and array literal declarations that have a comma immediately preceding the closing bracket or brace, which would cause an exception in IE7 and earlier.